### PR TITLE
Added Yason as dependency in cl-agraph.asd

### DIFF
--- a/cl-agraph.asd
+++ b/cl-agraph.asd
@@ -9,7 +9,7 @@
   :maintainer "Vsevolod Dyomkin <vseloved@gmail.com>"
   :licence "MIT"
   :description "A minimal portable Lisp client for AllegroGraph"
-  :depends-on (#:rutils #:cl-ppcre #:drakma #:cl-ntriples
+  :depends-on (#:rutils #:cl-ppcre #:drakma #:cl-ntriples #:yason
                         #+dev #:should-test)
   :serial t
   :components ((:module "src"


### PR DESCRIPTION
Thanks for writing this package.
I was getting an error finding Yason:parse when running the code in SBCL. I have just added Yason as dependency.
